### PR TITLE
Add 'hover' pseudo-event to no-event-shorthand

### DIFF
--- a/rules/no-event-shorthand.js
+++ b/rules/no-event-shorthand.js
@@ -30,6 +30,7 @@ module.exports = {
       'click',
       'contextmenu',
       'dblclick',
+      'hover',
       'mousedown',
       'mouseenter',
       'mouseleave',

--- a/tests/no-event-shorthand.js
+++ b/tests/no-event-shorthand.js
@@ -25,6 +25,7 @@ const forbidden = [
   'click',
   'contextmenu',
   'dblclick',
+  'hover',
   'mousedown',
   'mouseenter',
   'mouseleave',


### PR DESCRIPTION
'hover' will be deprecated along with other event shorthands.